### PR TITLE
Update documentation for current Mongo layout

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,14 +2,10 @@
 
 ## Project Structure & Module Organization
 - `Dockerfile` builds the custom MongoDB image used in CI and local builds.
-- `docker-compose.yml` runs MongoDB plus the `mongo-seed` container for data loading.
-- `docker-compose-stack.yml` is the swarm/Portainer stack definition with an NFS-backed volume.
-- `docker-compose-mongodb-community.yml` is a minimal community server example.
 - `mongo-seed/` contains the seed image (`Dockerfile`), `init.sh`, and JSON data under `collections/`.
 
 ## Build, Test, and Development Commands
 - `docker image build -t kernel528/mongodb-community-server:8.2.4-ubuntu2204-amd64 -f Dockerfile .` builds the image locally.
-- `docker-compose up --build` starts MongoDB plus the seed container and imports JSON data.
 - `docker container run -it --name mongodb-obiwan -d -p 27017:27017 -v mongo-obiwan-data:/data/db kernel528/mongodb-community-server:8.2.4-ubuntu2204-amd64` runs a standalone MongoDB container.
 - `docker stack deploy -c ../docker-swarm/stacks/mongo-stack.yml mongo` validates the image in the local swarm stack.
 - Drone CI in `.drone.yml` builds and tags images, runs a `mongosh` ping/CRUD smoke check, and executes `mongo-seed/init.sh`.

--- a/README.md
+++ b/README.md
@@ -7,9 +7,6 @@ This repository mirrors the official `mongodb/mongodb-community-server` image. T
 ### Project Structure
 ```
 project-root/
-├── docker-compose.yml
-├── docker-compose-stack.yml
-├── docker-compose-mongodb-community.yml
 ├── Dockerfile
 ├── mongo-seed/
 │   ├── Dockerfile
@@ -22,7 +19,7 @@ project-root/
 ### Workflow: Mirror Upstream Image
 1) Pull the latest upstream image and retag it for Docker Hub:
 ```bash
-VERSION=8.2.3
+VERSION=8.2.4
 
 docker image pull mongodb/mongodb-community-server:${VERSION}-ubuntu2204 --platform linux/amd64
 docker image tag mongodb/mongodb-community-server:${VERSION}-ubuntu2204 \
@@ -35,7 +32,7 @@ docker image push kernel528/mongodb-community-server:${VERSION}-ubuntu2204-amd64
 
 ### Build Base Image Locally
 ```bash
-docker image build -t kernel528/mongodb:${VERSION}-ubuntu2204 -f Dockerfile .
+docker image build -t kernel528/mongodb-community-server:${VERSION}-ubuntu2204-amd64 -f Dockerfile .
 ```
 
 ### Docker Swarm Validation
@@ -53,9 +50,6 @@ docker container run -it --name mongodb-obiwan --hostname mongo-docker -d \
 - No-auth example: `mongodb://localhost:27017`
 - With auth: `mongodb://<user>:<pass>@localhost:27017/?authSource=admin`
 
-### How to Use - docker-compose (Work in Progress)
-```bash
-docker-compose up --build
-```
-- The `mongo-seed` container runs `mongo-seed/init.sh` and imports all JSON files under `mongo-seed/collections/sample_*/*.json`.
-- Ensure required environment variables are set (e.g., `MONGO_INITDB_ROOT_USERNAME`, `MONGO_INITDB_ROOT_PASSWORD`, `MONGO_HOSTNAME`, `MONGO_DATABASE_NAME`).
+### Seed Data
+The `mongo-seed/init.sh` script imports JSON files under `mongo-seed/collections/sample_*/*.json`.
+Set `MONGO_URI` to the target database and optionally set `COLLECTIONS_DIR` to override the default collections path.


### PR DESCRIPTION
## Summary

- Remove stale compose file references that are no longer present in the repo.
- Update examples from MongoDB 8.2.3 to 8.2.4.
- Align build examples with the active `kernel528/mongodb-community-server` image name.
- Replace the removed docker-compose workflow section with seed script notes.

## Validation

- Ran `git diff --check` for the documentation changes.