### PR TITLE
Update MongoDB to 8.2.11 (upstream mirror)

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -22,7 +22,7 @@ steps:
         - linux/amd64
       repo: kernel528/mongodb-community-server
       tags:
-        - '8.2.4-pr-${DRONE_PULL_REQUEST}-amd64'
+        - '8.2.11-pr-${DRONE_PULL_REQUEST}-amd64'
       dry_run: true
 
   - name: mongodb-image-build-amd64-release
@@ -41,11 +41,11 @@ steps:
         - linux/amd64
       repo: kernel528/mongodb-community-server
       tags:
-        - '8.2.4'
-        - '8.2.4-drone-build-${DRONE_BUILD_NUMBER}-amd64'
+        - '8.2.11'
+        - '8.2.11-drone-build-${DRONE_BUILD_NUMBER}-amd64'
 
   - name: version-mongodb-amd64-test
-    image: kernel528/mongodb-community-server:8.2.4
+    image: kernel528/mongodb-community-server:8.2.11
     when:
       branch:
         - '8'
@@ -61,7 +61,7 @@ steps:
       - 'mongod --shutdown --dbpath /tmp/mongo-data'
 
   - name: version-mongo-seed-smoke-test
-    image: kernel528/mongodb-community-server:8.2.4
+    image: kernel528/mongodb-community-server:8.2.11
     when:
       branch:
         - '8'

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,11 +5,11 @@
 - `mongo-seed/` contains the seed image (`Dockerfile`), `init.sh`, and JSON data under `collections/`.
 
 ## Build, Test, and Development Commands
-- `docker image build -t kernel528/mongodb-community-server:8.2.4-ubuntu2204-amd64 -f Dockerfile .` builds the image locally.
-- `docker container run -it --name mongodb-obiwan -d -p 27017:27017 -v mongo-obiwan-data:/data/db kernel528/mongodb-community-server:8.2.4-ubuntu2204-amd64` runs a standalone MongoDB container.
+- `docker image build -t kernel528/mongodb-community-server:8.2.11-ubuntu2204-amd64 -f Dockerfile .` builds the image locally.
+- `docker container run -it --name mongodb-obiwan -d -p 27017:27017 -v mongo-obiwan-data:/data/db kernel528/mongodb-community-server:8.2.11-ubuntu2204-amd64` runs a standalone MongoDB container.
 - `docker stack deploy -c ../docker-swarm/stacks/mongo-stack.yml mongo` validates the image in the local swarm stack.
 - Drone CI in `.drone.yml` builds and tags images, runs a `mongosh` ping/CRUD smoke check, and executes `mongo-seed/init.sh`.
-  - When refreshing versions, update the explicit tags in `.drone.yml` (e.g., `8.2.4` and `8.2.4-drone-build-<build>-amd64`).
+  - When refreshing versions, update the explicit tags in `.drone.yml` (e.g., `8.2.11` and `8.2.11-drone-build-<build>-amd64`).
 
 ## Coding Style & Naming Conventions
 - YAML files use 2-space indentation; shell scripts use 2-space indentation where applicable.
@@ -21,7 +21,7 @@
 - If you add scripts, keep them idempotent and runnable in containers (see `mongo-seed/init.sh`).
 
 ## Commit & Pull Request Guidelines
-- No explicit commit convention is documented. Use clear, scoped messages such as `Update base image to 8.2.4`.
+- No explicit commit convention is documented. Use clear, scoped messages such as `Update base image to 8.2.11`.
 - PRs should note the MongoDB version/tag change, relevant compose file updates, and any seed data edits.
 - If the change affects runtime behavior, include the exact command used to verify it.
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # This is based on mongodb/mongodb-community-server:8.0.7-ubuntu2204 --platform=linux/amd64
-FROM kernel528/mongodb-community-server:8.2.4-ubuntu2204-amd64
+FROM kernel528/mongodb-community-server:8.2.11-ubuntu2204-amd64
 LABEL authors="kernel528@gmail.com"
 
 # Set environment variables for MongoDB initialization

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ project-root/
 ### Workflow: Mirror Upstream Image
 1) Pull the latest upstream image and retag it for Docker Hub:
 ```bash
-VERSION=8.2.4
+VERSION=8.2.11
 
 docker image pull mongodb/mongodb-community-server:${VERSION}-ubuntu2204 --platform linux/amd64
 docker image tag mongodb/mongodb-community-server:${VERSION}-ubuntu2204 \


### PR DESCRIPTION
## Changes

- **MongoDB**: `8.2.4` → `8.2.11` (latest 8.2.x patch)
- Pulled and retagged upstream `mongodb/mongodb-community-server:8.2.11-ubuntu2204` and pushed to `kernel528/mongodb-community-server:8.2.11-ubuntu2204-amd64`
- Updated `Dockerfile`, `.drone.yml`, `README.md`, `AGENTS.md` with new version tags

## Validation

- [x] Upstream image pulled and retagged
- [x] Image mirrored to Docker Hub (`kernel528/mongodb-community-server:8.2.11-ubuntu2204-amd64`)
- [x] Dockerfile build succeeded
- [x] `mongod --version` → `db version v8.2.11`